### PR TITLE
네이버 맛집 검색 크롤링01

### DIFF
--- a/네이버 맛집 검색 크롤링01
+++ b/네이버 맛집 검색 크롤링01
@@ -1,0 +1,17 @@
+#네이버 맛집 검색 크롤링
+from selenium import webdriver
+from selenium.webdriver.common.keys import Keys
+
+driver = webdriver.Chrome('c:\chromedriver.exe')
+url = 'https://www.naver.com/' #원하는 사이트를 입력하시오
+driver.implicitly_wait(3)
+driver.get(url)
+
+# 자동 검색
+search_box = driver.find_element_by_css_selector("input#query") # 검색창 마우스 클릭
+search_box.send_keys("남부터미널 한식 맛집") # 원하는 검색어 입력
+driver.find_element_by_xpath('//*[@id="search_btn"]').click() # 검색 버튼 클릭
+
+# 플레이스 하단 리스트 더 보기 클릭
+driver.find_element_by_xpath('//*[@id="loc-main-section-root"]/div/div/div[3]').click()
+driver.close()


### PR DESCRIPTION
1. 네이버 맵 페이지에 접속해서 '한식 맛집' 자동 검색하기
2. 자동 검색 코드를 작성하는 과정에서 네이버 맵 페이지에서 식당 리스트를 가져오려고 했으나 동적페이지라 html 코드를 분석하고 적용해도
코드가 작동하지 않았습니다. 이 문제점을 해결하기 위해 먼저 네이버 맵이 아닌 네이버 페이지로 방향을 바꾸고 코드도 수정하였습니다. 코드를 수정한 결과  식당명, 별점, 대표메뉴까지는 불러 올 수 있었습니다.
3. 다음 작업은 크롤링한 페이지에서 리스트가 나와 있는 페이지를 다음으로 넘기는 자동화를 할 예정입니다.